### PR TITLE
branche formation_form vers template_cv

### DIFF
--- a/src/Controller/FormationController.php
+++ b/src/Controller/FormationController.php
@@ -13,6 +13,7 @@ use Symfony\Component\Routing\Attribute\Route;
 
 #[Route('/profil/formation')]
 final class FormationController extends AbstractController{
+    
     #[Route(name: 'app_formation_index', methods: ['GET'])]
     public function index(FormationRepository $formationRepository): Response
     {
@@ -24,11 +25,17 @@ final class FormationController extends AbstractController{
     #[Route('/new', name: 'app_formation_new', methods: ['GET', 'POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): Response
     {
+        $user = $this->getUser();
         $formation = new Formation();
         $form = $this->createForm(FormationType::class, $formation);
         $form->handleRequest($request);
-
+        
         if ($form->isSubmitted() && $form->isValid()) {
+            $descriptions = $request->request->all()['description'] ?? [];
+            $formation->setDescription($descriptions);
+            
+            $formation->setStudent($user);
+
             $entityManager->persist($formation);
             $entityManager->flush();
 

--- a/src/Form/FormationType.php
+++ b/src/Form/FormationType.php
@@ -8,29 +8,138 @@ use App\Entity\Skill;
 use App\Entity\User;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CountryType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Regex;
 
 class FormationType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('date_start')
-            ->add('date_end')
-            ->add('title')
-            ->add('organization')
-            ->add('description')
-            ->add('postal_code')
-            ->add('city')
-            ->add('country')
-            ->add('level')
-            ->add('is_graduated')
-            ->add('degree')
+            ->add('date_start', TextType::class, [
+                'label' => 'Date de début',
+                'label_attr' => ['class' => 'block'],
+                'attr' => ['class' => 'border border-gray-300 rounded-md w-full p-1'],
+                'constraints' => [
+                    new NotBlank(
+                        message: "Ce champs est obligatoire"
+                    )
+                ]
+            ])
+            ->add('date_end', TextType::class, [
+                'label' => 'Date de fin',
+                'label_attr' => ['class' => 'block'],
+                'attr' => ['class' => 'border border-gray-300 rounded-md w-full p-1'],
+                'constraints' => [
+                    new NotBlank(
+                        message: "Ce champs est obligatoire"
+                    )
+                ]
+            ])
+            ->add('title', TextType::class, [
+                'label' => 'Titre',
+                'label_attr' => ['class' => 'block'],
+                'attr' => ['class' => 'border border-gray-300 rounded-md w-full p-1'],
+                'constraints' => [
+                    new NotBlank(
+                        message: "Ce champs est obligatoire"
+                    )
+                ]
+
+            ])
+            ->add('organization', TextType::class, [
+                'label' => 'organisation',
+                'label_attr' => ['class' => 'block'],
+                'attr' => ['class' => 'border border-gray-300 rounded-md w-full p-1'],
+                'constraints' => [
+                    new NotBlank(
+                        message: "Ce champs est obligatoire"
+                    )
+                ]
+            ])
+            ->add('description', TextType::class, [
+                'label' => 'description',
+                'label_attr' => ['class' => 'block'],
+                'attr' => ['class' => 'border border-gray-300 rounded-md w-full p-1'],
+                'constraints' => [
+                    new NotBlank(
+                        message: "Ce champs est obligatoire"
+                    )
+                ]
+            ])
+            ->add('postal_code', TextType::class, [
+                'label' => 'Code postal',
+                'label_attr' => ['class' => 'block'],
+                'attr' => ['class' => 'border border-gray-300 rounded-md w-full p-1'],
+                'constraints' => [
+                    new NotBlank(
+                        message: "Ce champs est obligatoire"
+                    ),
+                    new Length(
+                        min: 5,
+                        max: 5,
+                        minMessage: "Le code postal doit faire au moins {{ limit }} caractères",
+                        maxMessage: "Le code postal ne peut pas dépasser {{ limit }} caractères"
+                    ),
+                    new Regex(
+                        pattern: "/^[0-9]{5}$/",
+                        message: "Le code postal doit être composé de chiffres uniquement"
+                    )
+                ]
+            ])
+            ->add('city', TextType::class, [
+                'label' => 'ville',
+                'label_attr' => ['class' => 'block'],
+                'attr' => ['class' => 'border border-gray-300 rounded-md w-full p-1'],
+                'constraints' => [
+                    new NotBlank(
+                        message: "Ce champs est obligatoire"
+                    )
+                ]
+            ])
+            ->add('country', CountryType::class, [
+                'label' => 'pays',
+                'label_attr' => ['class' => 'block'],
+                'attr' => ['class' => 'border border-gray-300 rounded-md w-full p-1']
+            ])
+            ->add('level', TextType::class, [
+                'label' => 'Niveau',
+                'label_attr' => ['class' => 'block'],
+                'attr' => ['class' => 'border border-gray-300 rounded-md w-full p-1'],
+                'constraints' => [
+                    new NotBlank(
+                        message: "Ce champs est obligatoire"
+                    )
+                ]
+            ])
+            ->add('is_graduated', TextType::class, [
+                'label' => 'Diplômé',
+                'label_attr' => ['class' => 'block'],
+                'attr' => ['class' => 'border border-gray-300 rounded-md w-full p-1'],
+                'constraints' => [
+                    new NotBlank(
+                        message: "Ce champs est obligatoire"
+                    )
+                ]
+            ])
+            ->add('degree', TextType::class, [
+                'label' => 'Diplôme',
+                'label_attr' => ['class' => 'block'],
+                'attr' => ['class' => 'border border-gray-300 rounded-md w-full p-1']
+            ])
             ->add('skills', EntityType::class, [
+                'label' => "Compétences",
+                'label_attr' => ['class' => 'w-full bg-red-800'],
+                'attr' => ['class' => 'custom-wrapper'],
                 'class' => Skill::class,
-'choice_label' => 'id',
-'multiple' => true,
+                'choice_label' => 'name',
+                'multiple' => true,
+                'expanded' => true,
             ])
         ;
     }

--- a/templates/formation/_form.html.twig
+++ b/templates/formation/_form.html.twig
@@ -1,4 +1,82 @@
-{{ form_start(form) }}
-    {{ form_widget(form) }}
-    <button class="btn">{{ button_label|default('Save') }}</button>
-{{ form_end(form) }}
+<div class="max-w-2xl mx-auto p-6 bg-white rounded-lg shadow-md">
+	{{ form_start(form, {'attr': {'class': 'space-y-6'}}) }}
+
+	{# Date de début #}
+	<div class="form-group">
+		{{ form_label(form.date_start, 'Date de début', {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+		{{ form_widget(form.date_start, {'attr': {'class': 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'}}) }}
+	</div>
+
+	{# Date de fin #}
+	<div class="form-group">
+		{{ form_label(form.date_end, 'Date de fin', {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+		{{ form_widget(form.date_end, {'attr': {'class': 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'}}) }}
+	</div>
+
+	{# Titre #}
+	<div class="form-group">
+		{{ form_label(form.title, 'Titre', {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+		{{ form_widget(form.title, {'attr': {'class': 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'}}) }}
+	</div>
+
+	{# Organisation #}
+	<div class="form-group">
+		{{ form_label(form.organization, 'Organisation', {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+		{{ form_widget(form.organization, {'attr': {'class': 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'}}) }}
+	</div>
+
+	{# Description #}
+	<div class="form-group">
+		{{ form_label(form.description, 'Description', {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+		{{ form_widget(form.description, {'attr': {'class': 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'}}) }}
+	</div>
+
+	{# Code postal #}
+	<div class="form-group">
+		{{ form_label(form.postal_code, 'Code postal', {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+		{{ form_widget(form.postal_code, {'attr': {'class': 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'}}) }}
+	</div>
+
+	{# Ville #}
+	<div class="form-group">
+		{{ form_label(form.city, 'Ville', {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+		{{ form_widget(form.city, {'attr': {'class': 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'}}) }}
+	</div>
+
+	{# Pays #}
+	<div class="form-group">
+		{{ form_label(form.country, 'Pays', {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+		{{ form_widget(form.country, {'attr': {'class': 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'}}) }}
+	</div>
+
+	{# Niveau #}
+	<div class="form-group">
+		{{ form_label(form.level, 'Niveau', {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+		{{ form_widget(form.level, {'attr': {'class': 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'}}) }}
+	</div>
+
+	{# Diplômé #}
+	<div class="form-group">
+		{{ form_label(form.is_graduated, 'Diplômé', {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+		{{ form_widget(form.is_graduated, {'attr': {'class': 'mt-1 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500'}}) }}
+	</div>
+
+	{# Diplôme #}
+	<div class="form-group">
+		{{ form_label(form.degree, 'Diplôme', {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+		{{ form_widget(form.degree, {'attr': {'class': 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'}}) }}
+	</div>
+
+	{# Compétences #}
+	<div class="form-group">
+		{{ form_label(form.skills, 'Compétences', {'label_attr': {'class': 'block text-sm font-medium text-gray-700'}}) }}
+		{{ form_widget(form.skills, {'attr': {'class': 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'}}) }}
+	</div>
+
+	<div class="flex items-center justify-end mt-6">
+		<button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+			{{ button_label|default('Enregistrer') }}
+		</button>
+	</div>
+	{{ form_end(form) }}
+</div>


### PR DESCRIPTION
## Liste des modifications et ajouts entre les branches template_cv et formation_form :

#### FormationController.php :


> ✅ Ajout de la récupération de l'utilisateur courant dans la méthode new.
> ✅ Ajout de la gestion des descriptions et de l'association de l'utilisateur à la formation lors de la création d'une nouvelle formation

#### FormationType.php :

> ✅ Ajout de plusieurs contraintes de validation pour les champs du formulaire, y compris NotBlank, Length, et Regex.
> ✅ Ajout des champs avec des types de données spécifiques (e.g., TextType, CountryType).
> ☑️ Modification de certains labels et attributs pour les rendre plus descriptifs et ergonomiques.

####  _form.html.twig :

> ✅ Réécriture complète du formulaire avec des classes CSS pour une meilleure mise en page et une apparence plus moderne.
> ✅ Ajout de labels descriptifs et de widgets de formulaire avec des classes spécifiques pour une meilleure expérience utilisateur.

Pour plus de détails, vous pouvez consulter les modifications [ici](https://github.com/Brdlucas/ProfilAuTop/compare/template_cv...formation_form).