### PR TITLE
merge de la branche template_cv vers Dev

### DIFF
--- a/src/Controller/CvController.php
+++ b/src/Controller/CvController.php
@@ -19,8 +19,16 @@ final class CvController extends AbstractController
     #[Route(name: 'app_cv_index', methods: ['GET'])]
     public function index(CvRepository $cvRepository): Response
     {
+        $user = $this->getUser();
+
+        $userID = $user->getId(); // Assurez-vous que getRef() existe et retourne la référence correcte
+        $cvs = $cvRepository->findBy(['creator' => $userID]);
+
+        // dd($userRef);
+        // dd($cvs);
+
         return $this->render('cv/index.html.twig', [
-            'cvs' => $cvRepository->findAll(),
+            'cvs' => $cvs,
         ]);
     }
 

--- a/src/Controller/CvController.php
+++ b/src/Controller/CvController.php
@@ -28,10 +28,12 @@ final class CvController extends AbstractController
     public function new(Request $request, EntityManagerInterface $entityManager): Response
     {
         $cv = new Cv();
+        $user = $this->getUser();
         $form = $this->createForm(CvType::class, $cv);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $form->getData()->setCreator($user);
             $entityManager->persist($cv);
             $entityManager->flush();
 

--- a/src/Controller/ExperienceController.php
+++ b/src/Controller/ExperienceController.php
@@ -30,12 +30,12 @@ final class ExperienceController extends AbstractController
         $experience = new Experience();
         $form = $this->createForm(ExperienceType::class, $experience);
         $form->handleRequest($request);
-        
+
         if ($form->isSubmitted() && $form->isValid()) {
             $action = $request->get('action');
             $descriptions = $request->request->all()['description'] ?? [];
             $experience->setDescription($descriptions);
-            
+
             $experience->setEmployee($user);
 
             $entityManager->persist($experience);
@@ -47,7 +47,7 @@ final class ExperienceController extends AbstractController
                     return $this->redirectToRoute('app_experience_new', [], Response::HTTP_SEE_OTHER);
                     break;
                 case 'next':
-                    return $this->redirectToRoute('app_skill_new', [], Response::HTTP_SEE_OTHER);
+                    return $this->redirectToRoute('app_cv_new', [], Response::HTTP_SEE_OTHER);
                     break;
             }
         }

--- a/src/Entity/Cv.php
+++ b/src/Entity/Cv.php
@@ -70,16 +70,9 @@ class Cv
      */
     private $skills;
 
-
-    /**
-     * @var Collection<int, SoftSkill>
-     */
-    #[ORM\ManyToMany(targetEntity: SoftSkill::class, inversedBy: 'cvs')]
-    private Collection $softskills;
-
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $ai = null;
-  
+
     /**
      * @var Collection<int, SoftSkill>
      */
@@ -127,6 +120,7 @@ class Cv
     public function setCreatedAtValue()
     {
         $this->created_at = new \DateTimeImmutable();
+        $this->updated_at = new \DateTimeImmutable();
     }
 
     #[ORM\PreUpdate]

--- a/src/Form/CvType.php
+++ b/src/Form/CvType.php
@@ -4,15 +4,17 @@ namespace App\Form;
 
 use App\Entity\Cv;
 use App\Entity\Category;
-use App\Entity\Experience;
 use App\Entity\Formation;
-use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use App\Entity\SoftSkill;
+use App\Entity\Experience;
+use App\Entity\Offer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CvType extends AbstractType
 {
@@ -26,15 +28,6 @@ class CvType extends AbstractType
                 ],
                 'label' => 'Titre',
                 'required' => true,
-            ])
-            ->add('introduction', TextareaType::class, [
-                'attr' => [
-                    'class' => 'p-5',
-                    'placeholder' => 'Présentez-vous brièvement',
-                    'rows' => 4
-                ],
-                'label' => 'Introduction',
-                'required' => false,
             ])
             ->add('date_start', TextType::class, [
                 'attr' => [
@@ -53,17 +46,7 @@ class CvType extends AbstractType
                 'label' => 'Date de fin',
                 'required' => false,
             ])
-            ->add('categories', EntityType::class, [
-                'class' => Category::class,
-                'choice_label' => 'name',
-                'multiple' => true,
-                'expanded' => true,
-                'attr' => [
-                    'class' => 'block max-h-60 overflow-y-auto rounded-md border-gray-300'
-                ],
-                'label' => 'Catégories',
-                'required' => false,
-            ])
+
             ->add('experiences', EntityType::class, [
                 'class' => Experience::class,
                 'choice_label' => function ($entity) {
@@ -90,13 +73,18 @@ class CvType extends AbstractType
                 'label' => 'Formations',
                 'required' => false,
             ])
-            ->add('link', TextType::class, [
-                'attr' => [
-                    'class' => 'p-5',
-                    'placeholder' => 'Lien vers votre CV / Portfolio'
-                ],
-                'label' => 'Lien',
-                'required' => false,
+            ->add('softskills', EntityType::class, [
+                'label' => 'Compétences personnelles',
+                'class' => SoftSkill::class,
+                'choice_label' => 'name',
+                'multiple' => true,
+                'autocomplete' => true,
+            ])
+            ->add('offer', EntityType::class, [
+                'label' => 'Poster sur l\'Offre',
+                'class' => Offer::class,
+                'multiple' => false,
+                'autocomplete' => true,
             ])
         ;
     }

--- a/templates/cv/_form.html.twig
+++ b/templates/cv/_form.html.twig
@@ -1,6 +1,5 @@
 {{ form_start(form, {'attr': {'class': 'p-2 bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 flex flex-col w-4/5 mt-10 m-auto gap-5'}}) }}
 <div class="max-w-7xl mx-auto space-y-6">
-	{{ dump(form) }}
 	{% for field in form %}
 		{% if field.vars.name in ['categories', 'experiences', 'formations'] %}
 			<div class="form-section">
@@ -28,7 +27,13 @@
 				</div>
 			</div>
 		{% else %}
-			<div class="bg-white rounded-lg border border-gray-200">
+			<div class="">
+				{{ form_label(field, null, {
+					'label_attr': {
+						'class': 'text-xl'
+					}
+				}) }}
+
 				{{ form_widget(field, {
                         'attr': {
                             'class': 'block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'
@@ -38,4 +43,4 @@
 		</div>
 	{% endif %}
 {% endfor %}</div><button class="mt-6 m-auto px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-{{ button_label|default('Créer un nouveau CV') }}</button>{{ form_end(form) }}
+{{ button_label|default('Créer un nouveau CV') }}</button>{{ form_widget(form._token) }}{{ form_end(form, {'render_rest': false}) }}

--- a/templates/cv/_form.html.twig
+++ b/templates/cv/_form.html.twig
@@ -1,49 +1,55 @@
 {{ form_start(form, {'attr': {'class': 'p-2 bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 flex flex-col w-4/5 mt-10 m-auto gap-5'}}) }}
 <div class="max-w-7xl mx-auto space-y-6">
 	{% for field in form %}
-		{% if field.vars.name != '_token' %}
-			{# Ajoutez cette condition #}
-			{% if field.vars.name in ['categories', 'experiences', 'formations'] %}
-				<div class="form-section">
-					<h3 class="text-lg font-medium text-gray-900 mb-3">
-						{% if field.vars.name == 'categories' %}Catégories
-							{% elseif field.vars.name == 'experiences' %}Expériences
-							{% else %}Formations
-						{% endif %}
-					</h3>
-					<div class="grid grid-cols-2 md:grid-cols-3 gap-3">
-						{% for choice in field %}
-							<div class="relative flex items-center px-4 py-3 bg-white rounded-lg border border-gray-200 hover:border-indigo-500 transition-colors">
-								{{ form_widget(choice, {
+		{% if field.vars.name in ['categories', 'experiences', 'formations'] %}
+			<div class="form-section">
+				<h3 class="text-lg font-medium text-gray-900 mb-3">
+					{% if field.vars.name == 'categories' %}Catégories
+						{% elseif field.vars.name == 'experiences' %}Expériences
+						{% else %}Formations
+					{% endif %}
+				</h3>
+				<div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+					{% for choice in field %}
+						<div class="relative flex items-center px-4 py-3 bg-white rounded-lg border border-gray-200 hover:border-indigo-500 transition-colors">
+							{{ form_widget(choice, {
                                 'attr': {
                                     'class': 'h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500'
                                 }
                             }) }}
-								{{ form_label(choice, null, {
+							{{ form_label(choice, null, {
                                 'label_attr': {
                                     'class': 'ml-3 text-sm font-medium text-gray-700 cursor-pointer'
                                 }
                             }) }}
-							</div>
-						{% endfor %}
-					</div>
+						</div>
+					{% endfor %}
+				</div>
+			</div>
+		{% else %}
+			{% if field.vars.name == '_token' %}
+				<div style="display: none;">
+					{{ form_widget(field) }}
 				</div>
 			{% else %}
 				<div class="">
 					{{ form_label(field, null, {
-					'label_attr': {
-						'class': 'text-xl'
-					}
-				}) }}
+                'label_attr': {
+                    'class': 'text-xl'
+                }
+            }) }}
 
 					{{ form_widget(field, {
-                        'attr': {
-                            'class': 'block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'
-                        }
-                    }) }}
+                'attr': {
+                    'class': 'block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'
+                }
+            }) }}
 				</div>
-			</div>
+			{% endif %}
 		{% endif %}
-	{% endif %}
-{% endfor %}</div><button class="mt-6 m-auto px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-{{ button_label|default('Créer un nouveau CV') }}</button>{{ form_end(form, {'render_rest': false}) }}
+
+	{% endfor %}
+</div>
+<button class="mt-6 m-auto px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+	{{ button_label|default('Créer un nouveau CV') }}</button>
+{{ form_end(form, {'render_rest': false}) }}

--- a/templates/cv/_form.html.twig
+++ b/templates/cv/_form.html.twig
@@ -1,46 +1,49 @@
 {{ form_start(form, {'attr': {'class': 'p-2 bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4 flex flex-col w-4/5 mt-10 m-auto gap-5'}}) }}
 <div class="max-w-7xl mx-auto space-y-6">
 	{% for field in form %}
-		{% if field.vars.name in ['categories', 'experiences', 'formations'] %}
-			<div class="form-section">
-				<h3 class="text-lg font-medium text-gray-900 mb-3">
-					{% if field.vars.name == 'categories' %}Catégories
-						{% elseif field.vars.name == 'experiences' %}Expériences
-						{% else %}Formations
-					{% endif %}
-				</h3>
-				<div class="grid grid-cols-2 md:grid-cols-3 gap-3">
-					{% for choice in field %}
-						<div class="relative flex items-center px-4 py-3 bg-white rounded-lg border border-gray-200 hover:border-indigo-500 transition-colors">
-							{{ form_widget(choice, {
+		{% if field.vars.name != '_token' %}
+			{# Ajoutez cette condition #}
+			{% if field.vars.name in ['categories', 'experiences', 'formations'] %}
+				<div class="form-section">
+					<h3 class="text-lg font-medium text-gray-900 mb-3">
+						{% if field.vars.name == 'categories' %}Catégories
+							{% elseif field.vars.name == 'experiences' %}Expériences
+							{% else %}Formations
+						{% endif %}
+					</h3>
+					<div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+						{% for choice in field %}
+							<div class="relative flex items-center px-4 py-3 bg-white rounded-lg border border-gray-200 hover:border-indigo-500 transition-colors">
+								{{ form_widget(choice, {
                                 'attr': {
                                     'class': 'h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500'
                                 }
                             }) }}
-							{{ form_label(choice, null, {
+								{{ form_label(choice, null, {
                                 'label_attr': {
                                     'class': 'ml-3 text-sm font-medium text-gray-700 cursor-pointer'
                                 }
                             }) }}
-						</div>
-					{% endfor %}
+							</div>
+						{% endfor %}
+					</div>
 				</div>
-			</div>
-		{% else %}
-			<div class="">
-				{{ form_label(field, null, {
+			{% else %}
+				<div class="">
+					{{ form_label(field, null, {
 					'label_attr': {
 						'class': 'text-xl'
 					}
 				}) }}
 
-				{{ form_widget(field, {
+					{{ form_widget(field, {
                         'attr': {
                             'class': 'block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500'
                         }
                     }) }}
+				</div>
 			</div>
-		</div>
+		{% endif %}
 	{% endif %}
 {% endfor %}</div><button class="mt-6 m-auto px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-{{ button_label|default('Créer un nouveau CV') }}</button>{{ form_widget(form._token) }}{{ form_end(form, {'render_rest': false}) }}
+{{ button_label|default('Créer un nouveau CV') }}</button>{{ form_end(form, {'render_rest': false}) }}

--- a/templates/cv/index.html.twig
+++ b/templates/cv/index.html.twig
@@ -12,12 +12,10 @@
 				<th>Id</th>
 				<th>Ref</th>
 				<th>Title</th>
-				<th>Introduction</th>
 				<th>Date_start</th>
 				<th>Date_end</th>
 				<th>Created_at</th>
 				<th>Updated_at</th>
-				<th>Link</th>
 				<th>actions</th>
 			</tr>
 		</thead>
@@ -27,12 +25,10 @@
 					<td>{{ cv.id }}</td>
 					<td>{{ cv.ref }}</td>
 					<td>{{ cv.title }}</td>
-					<td>{{ cv.introduction }}</td>
 					<td>{{ cv.dateStart }}</td>
 					<td>{{ cv.dateEnd }}</td>
 					<td>{{ cv.createdAt ? cv.createdAt|date('Y-m-d H:i:s') : '' }}</td>
 					<td>{{ cv.updatedAt ? cv.updatedAt|date('Y-m-d H:i:s') : '' }}</td>
-					<td>{{ cv.link }}</td>
 					<td>
 						<a href="{{ path('app_cv_show', {'id': cv.id}) }}">show</a>
 						<a href="{{ path('app_cv_edit', {'id': cv.id}) }}">edit</a>

--- a/templates/cv/index.html.twig
+++ b/templates/cv/index.html.twig
@@ -1,46 +1,88 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}Cv index
+{% block title %}CV Index
 {% endblock %}
 
 {% block body %}
-	<h1>Cv index</h1>
-
-	<table class="table">
-		<thead>
-			<tr>
-				<th>Id</th>
-				<th>Ref</th>
-				<th>Title</th>
-				<th>Date_start</th>
-				<th>Date_end</th>
-				<th>Created_at</th>
-				<th>Updated_at</th>
-				<th>actions</th>
-			</tr>
-		</thead>
-		<tbody>
-			{% for cv in cvs %}
-				<tr>
-					<td>{{ cv.id }}</td>
-					<td>{{ cv.ref }}</td>
-					<td>{{ cv.title }}</td>
-					<td>{{ cv.dateStart }}</td>
-					<td>{{ cv.dateEnd }}</td>
-					<td>{{ cv.createdAt ? cv.createdAt|date('Y-m-d H:i:s') : '' }}</td>
-					<td>{{ cv.updatedAt ? cv.updatedAt|date('Y-m-d H:i:s') : '' }}</td>
-					<td>
-						<a href="{{ path('app_cv_show', {'id': cv.id}) }}">show</a>
-						<a href="{{ path('app_cv_edit', {'id': cv.id}) }}">edit</a>
-					</td>
-				</tr>
-			{% else %}
-				<tr>
-					<td colspan="10">no records found</td>
-				</tr>
-			{% endfor %}
-		</tbody>
-	</table>
-
-	<a href="{{ path('app_formation_new') }}">Create new</a>
+	<div class="container mx-auto px-4 sm:px-8">
+		<div class="py-8">
+			<h1 class="text-2xl font-semibold leading-tight">CV Index</h1>
+			<div class="my-2 flex sm:flex-row flex-col">
+				<div class="flex flex-row mb-1 sm:mb-0">
+					<div class="relative">
+						<a href="{{ path('app_formation_new') }}" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+							Nouveau CV
+						</a>
+					</div>
+				</div>
+			</div>
+			<div class="-mx-4 sm:-mx-8 px-4 sm:px-8 py-4 overflow-x-auto">
+				<div class="inline-block min-w-full shadow rounded-lg overflow-hidden">
+					<table class="min-w-full leading-normal">
+						<thead>
+							<tr>
+								<th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+									Id
+								</th>
+								<th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+									Ref
+								</th>
+								<th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+									Title
+								</th>
+								<th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+									Date Start
+								</th>
+								<th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+									Date End
+								</th>
+								<th class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+									Actions
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{% if cvs is iterable %}
+								{% for cv in cvs %}
+									<tr>
+										<td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+											<p class="text-gray-900 whitespace-no-wrap">{{ cv.id }}</p>
+										</td>
+										<td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+											<p class="text-gray-900 whitespace-no-wrap">{{ cv.ref }}</p>
+										</td>
+										<td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+											<p class="text-gray-900 whitespace-no-wrap">{{ cv.title }}</p>
+										</td>
+										<td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+											<p class="text-gray-900 whitespace-no-wrap">{{ cv.dateStart }}</p>
+										</td>
+										<td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+											<p class="text-gray-900 whitespace-no-wrap">{{ cv.dateEnd }}</p>
+										</td>
+										<td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+											<a href="{{ path('app_cv_show', {'id': cv.id}) }}" class="text-blue-600 hover:text-blue-900 mr-2">Show</a>
+											<a href="{{ path('app_cv_edit', {'id': cv.id}) }}" class="text-green-600 hover:text-green-900">Edit</a>
+										</td>
+									</tr>
+								{% else %}
+									<tr>
+										<td colspan="6" class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+											<p class="text-gray-900 whitespace-no-wrap text-center">No records found</p>
+										</td>
+									</tr>
+								{% endfor %}
+							{% else %}
+								<tr>
+									<td colspan="6" class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+										<p class="text-gray-900 whitespace-no-wrap text-center">Invalid data format</p>
+									</td>
+								</tr>
+							{% endif %}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
 {% endblock %}


### PR DESCRIPTION
### Description des modifications pour le merge de la branche `template_cv` vers `dev` :

#### Ajouts :
- ✅Ajout de la récupération de l'utilisateur connecté et de ses CVs dans `CvController`.
- ✅Ajout de la liaison des CVs à l'utilisateur dans `new` de `CvController`.
- ☑️ Mise à jour automatique de la date de mise à jour (`updated_at`) dans l'entité `Cv`.

#### Modifications :
- ✏️ Modification de la méthode `index` de `CvController` pour filtrer les CVs par utilisateur.
- ✏️ Modification de la méthode `new` de `ExperienceController` pour rediriger vers `app_cv_new` au lieu de `app_skill_new`.
- ➖ Ajustements du formulaire `CvType` pour inclure des compétences personnelles (`softskills`) et une offre (`offer`).

#### Suppressions :
- ❌ Suppression du champ `introduction` et de la section `categories` du formulaire `CvType`.
- ❌ Suppression des éléments de débogage (`dump`) dans le template `_form.html.twig`.

Pour plus de détails, [cliquez ici](https://github.com/Brdlucas/ProfilAuTop/compare/dev...template_cv).